### PR TITLE
add reference docker implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Also make also sure to cite additional papers when using datasets or superpixel 
 
 **Updates:**
 
+* A docker implementation containing many of the algorithms was added to [./docker](./docker/).
 * An implementation of the average metrics, i.e. Average Boundary Recall (called
 Average Miss Rate in the updated paper), Average Undersegmentation Error
 and Average Explained Variation (called Average Unexplained Variation in the updated paper)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,70 @@
+FROM python:3.11.4-buster
+RUN export DEBIAN_FRONTEND="noninteractive"
+ENV APP_HOME /app
+
+RUN apt-get update && \
+	apt-get install -qq -y \
+		autotools-dev \
+		automake \
+		build-essential \
+		cimg-dev \
+		cimg-doc \
+		cimg-examples \
+		cmake \
+		ffmpeg \
+		git \
+		graphicsmagick-imagemagick-compat \
+		libboost-all-dev \
+		libeigen3-dev \
+		libopencv-dev \
+		libpng-dev \
+		libpng++-dev \
+		potrace \
+	&& apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p $APP_HOME/
+
+RUN apt-get update && \
+	apt-get install -qq -y \
+		libgoogle-glog-dev \
+		libpcl-dev \
+		libusb-1.0-0 \
+		libopenni2-0 \
+		libpcap0.8 \
+	&& apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd /usr/local/include && \
+	ln -sf eigen3/Eigen Eigen
+	#ln -sf eigen3/unsupported unsupported
+# the commented out line above helps depending on the base image. python ones dont need it.
+
+# Clone repo and get it ready for compilation
+RUN git clone https://github.com/davidstutz/superpixel-benchmark/ $APP_HOME/super
+# patch contains minor updates. not all algorithms are built, but many are. 
+COPY docker.patch $APP_HOME/super/
+RUN cd $APP_HOME/super && \
+    git apply docker.patch && \
+    git submodule update --init --recursive
+
+RUN cd $APP_HOME/super && \
+	mkdir build && \
+	cd build && \
+	#cmake .. -DGLOG_ROOT_DIR=/app/glog && \
+	cmake .. && \
+	make
+
+WORKDIR $APP_HOME
+# dumb-init for proper handling of control-signals when interacting with the container
+RUN apt-get update && \
+	apt-get install -qq -y \
+	dumb-init \
+	&& apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# adding a non-root user, helps with permissions on mounted volumes
+RUN useradd -m super
+RUN chown -R super:super $APP_HOME
+USER super
+ENTRYPOINT ["dumb-init", "--"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,48 @@
+# Docker image
+As years pass by and operating systems get upgraded, it's important to have at least a working snapshot of a computational environment.
+
+A docker image has been contributed to help facilitate the use of many of the algorithms. It is not complete in scope, but should act as a starting place for compiling and using the code in this repository.
+
+A `makefile` is supplied with example usage of the container, including an example of how to prepare images for the algorithms.
+
+`ffmpeg`, `graphicsmagick`, and `potrace` are installed in the container as utilities related to image processing. `git` and `python 3.11.4` are also bundled.
+
+
+## Changes
+In addition to the algorithms enabled by default, the following have been changed to `ON`:
+
+- BUILD_VC
+- BUILD_FH
+- BUILD_MSS
+- BUILD_PB
+- BUILD_PRESLIC
+- BUILD_W
+- BUILD_LSC
+- BUILD_CCS
+- BUILD_DASP
+- BUILD_VCCS
+- BUILD_REFH
+- BUILD_VLSLIC
+
+BUILD_CIS is `OFF` due to licensing
+BUILD_CW is `OFF` due to cvGetMatSize declaration error
+
+The Matlab algorithms have been left disabled due to licensing concerns with the language.
+If you know how to safely ship matlab in a container (or want to attempt a migration to Octave), contributions are welcome.
+
+
+# Quick Start
+Reference the `makefile` (which acts like a collection of shell-scripts), for docker usage syntax. Adapt it to your needs, as it is meant to provide a reference implementation which may or may not align with your expectations (e.g., folder names, locations, etc).
+
+```bash
+make run
+```
+
+Will start `bash` in an interactive emphemeral container, with `raw` being a read-only bind-mounted directory, and `in` being where you put `.bmp` images. See `make convert` for an example of how to prepare your images using the docker container.
+
+There is an example of one algorithm's syntax in the [`makefile`][./makefile]:
+
+```bash
+make help_mss
+```
+

--- a/docker/docker.patch
+++ b/docker/docker.patch
@@ -1,0 +1,299 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 104fd9d..e327f13 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,22 +45,20 @@ option(BUILD_CRS "Build CRS" ON)
+ option(BUILD_ERGC "Build ERGC" ON)
+ 
+ # Remaining algorithms:
+-option(BUILD_FH "Build FH" OFF)
+-option(BUILD_MSS "Build MSS" OFF)
+-option(BUILD_PB "Build PB" OFF)
+-option(BUILD_PRESLIC "Build preSLIC" OFF)
+-option(BUILD_CW "Build CW" OFF)
+-option(BUILD_CIS "Build CIS" OFF)
+-option(BUILD_W "Build W" OFF)
+-option(BUILD_LSC "Build LSC" OFF)
+-option(BUILD_VC "Build VC" OFF)
+-option(BUILD_CCS "Build CCS" OFF)
+-option(BUILD_VC "Build VC" OFF)
+-option(BUILD_CCS "Build CCS" OFF)
+-option(BUILD_DASP "Build DASP" OFF)
+-option(BUILD_VCCS "Build VCCS" OFF)
++option(BUILD_VC "Build VC" ON)
++option(BUILD_FH "Build FH" ON)
++option(BUILD_MSS "Build MSS" ON)
++option(BUILD_PB "Build PB" ON)
++option(BUILD_PRESLIC "Build preSLIC" ON)
++option(BUILD_CW "Build CW" OFF)  # cvGetMatSize declaration error
++option(BUILD_CIS "Build CIS" OFF) # licensing
++option(BUILD_W "Build W" ON)
++option(BUILD_LSC "Build LSC" ON)
++option(BUILD_CCS "Build CCS" ON)
++option(BUILD_DASP "Build DASP" ON) # needed eigen imports
++option(BUILD_VCCS "Build VCCS" ON)
+ option(BUILD_REFH "Build reFH" ON)
+-option(BUILD_VLSLIC "Build vlSLIC" OFF)
++option(BUILD_VLSLIC "Build vlSLIC" ON)
+ 
+ # Examples:
+ option(BUILD_EXAMPLES "Build examples" ON)
+diff --git a/lib_dasp/lib_dasp/Graph.hpp b/lib_dasp/lib_dasp/Graph.hpp
+index f095835..75d3f85 100644
+--- a/lib_dasp/lib_dasp/Graph.hpp
++++ b/lib_dasp/lib_dasp/Graph.hpp
+@@ -12,7 +12,7 @@
+ #include "as_range.hpp"
+ #include "graphseg.hpp"
+ #include <boost/graph/adjacency_list.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ 
+ namespace dasp
+ {
+diff --git a/lib_dasp/lib_dasp/IO.hpp b/lib_dasp/lib_dasp/IO.hpp
+index 8f74c64..dfd2770 100644
+--- a/lib_dasp/lib_dasp/IO.hpp
++++ b/lib_dasp/lib_dasp/IO.hpp
+@@ -2,7 +2,7 @@
+ #define INCLUDED_DASP_IO_HPP_
+ 
+ #include "Graph.hpp"
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/lib_dasp/lib_dasp/Metric.hpp b/lib_dasp/lib_dasp/Metric.hpp
+index c3d06c1..43828ee 100644
+--- a/lib_dasp/lib_dasp/Metric.hpp
++++ b/lib_dasp/lib_dasp/Metric.hpp
+@@ -11,7 +11,7 @@
+ #include "Point.hpp"
+ #include <Danvil/Tools/MoreMath.h>
+ #include <Danvil/Tools/FunctionCache.h>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ 
+ namespace dasp
+ {
+diff --git a/lib_dasp/lib_dasp/Neighbourhood.hpp b/lib_dasp/lib_dasp/Neighbourhood.hpp
+index 2ef4dbc..e6a4ca4 100644
+--- a/lib_dasp/lib_dasp/Neighbourhood.hpp
++++ b/lib_dasp/lib_dasp/Neighbourhood.hpp
+@@ -13,7 +13,7 @@
+ #include <Slimage/Slimage.hpp>
+ #include <boost/graph/adjacency_list.hpp>
+ #include <boost/graph/copy.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace dasp
+diff --git a/lib_dasp/lib_dasp/Plots.cpp b/lib_dasp/lib_dasp/Plots.cpp
+index 0b76fef..181a868 100644
+--- a/lib_dasp/lib_dasp/Plots.cpp
++++ b/lib_dasp/lib_dasp/Plots.cpp
+@@ -17,7 +17,7 @@
+ #include <Danvil/Color.h>
+ #include <Danvil/Color/LAB.h>
+ #include <Danvil/Color/HSV.h>
+-#include <Eigen/Geometry>
++#include <eigen3/Eigen/Geometry>
+ #include <cmath>
+ #include <iostream>
+ 
+diff --git a/lib_dasp/lib_dasp/Point.hpp b/lib_dasp/lib_dasp/Point.hpp
+index 7dc12ba..654fab3 100644
+--- a/lib_dasp/lib_dasp/Point.hpp
++++ b/lib_dasp/lib_dasp/Point.hpp
+@@ -11,7 +11,7 @@
+ #include "Parameters.hpp"
+ #include "Array.hpp"
+ #include <Danvil/Tools/MoreMath.h>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace dasp
+diff --git a/lib_dasp/lib_dasp/Seed.hpp b/lib_dasp/lib_dasp/Seed.hpp
+index a2e3f08..63d0247 100644
+--- a/lib_dasp/lib_dasp/Seed.hpp
++++ b/lib_dasp/lib_dasp/Seed.hpp
+@@ -8,7 +8,7 @@
+ #ifndef DASP_SEED_HPP_
+ #define DASP_SEED_HPP_
+ 
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ 
+ namespace dasp
+ {
+diff --git a/lib_dasp/lib_dasp/Segmentation.hpp b/lib_dasp/lib_dasp/Segmentation.hpp
+index f129901..a598fd2 100644
+--- a/lib_dasp/lib_dasp/Segmentation.hpp
++++ b/lib_dasp/lib_dasp/Segmentation.hpp
+@@ -13,7 +13,7 @@
+ #include <Labeling.hpp>
+ #include <graphseg.hpp>
+ #include <Slimage/Slimage.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <boost/graph/adjacency_list.hpp>
+ #include <boost/graph/copy.hpp>
+ #include <vector>
+diff --git a/lib_dasp/lib_dasp/impl/Clustering.hpp b/lib_dasp/lib_dasp/impl/Clustering.hpp
+index 312b949..397e008 100644
+--- a/lib_dasp/lib_dasp/impl/Clustering.hpp
++++ b/lib_dasp/lib_dasp/impl/Clustering.hpp
+@@ -12,7 +12,7 @@
+ #include "../Parameters.hpp"
+ #include "../Metric.hpp"
+ #include <Slimage/Slimage.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <iostream>
+ 
+ namespace dasp
+diff --git a/lib_dasp/lib_dasp/impl/Sampling.hpp b/lib_dasp/lib_dasp/impl/Sampling.hpp
+index 37c00c2..39bd014 100644
+--- a/lib_dasp/lib_dasp/impl/Sampling.hpp
++++ b/lib_dasp/lib_dasp/impl/Sampling.hpp
+@@ -10,7 +10,7 @@
+ 
+ #include "../Point.hpp"
+ #include "../Seed.hpp"
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace dasp
+diff --git a/lib_dasp/lib_dasp_common/color.hpp b/lib_dasp/lib_dasp_common/color.hpp
+index 49ce261..755fa0f 100644
+--- a/lib_dasp/lib_dasp_common/color.hpp
++++ b/lib_dasp/lib_dasp_common/color.hpp
+@@ -2,7 +2,7 @@
+ #define COMMON_COLOR_HPP_
+ //----------------------------------------------------------------------------//
+ #include <Danvil/Color.h>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <Slimage/Slimage.hpp>
+ //----------------------------------------------------------------------------//
+ namespace common {
+diff --git a/lib_dasp/lib_dasp_density/density/PointDensity.hpp b/lib_dasp/lib_dasp_density/density/PointDensity.hpp
+index 7432a0f..fc9c643 100644
+--- a/lib_dasp/lib_dasp_density/density/PointDensity.hpp
++++ b/lib_dasp/lib_dasp_density/density/PointDensity.hpp
+@@ -2,7 +2,7 @@
+ #define INCLUDED_PDS_DENSITY_HPP
+ 
+ #include <Danvil/Tools/FunctionCache.h>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace density
+diff --git a/lib_dasp/lib_dasp_density/density/ScalePyramid.hpp b/lib_dasp/lib_dasp_density/density/ScalePyramid.hpp
+index ca0fabf..0447909 100644
+--- a/lib_dasp/lib_dasp_density/density/ScalePyramid.hpp
++++ b/lib_dasp/lib_dasp_density/density/ScalePyramid.hpp
+@@ -9,7 +9,7 @@
+ #define INCLUDED_DENSITY_SCALEPYRAMID_HPP_
+ 
+ #include <Slimage/Slimage.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <stdexcept>
+ #include <vector>
+ #include <tuple>
+diff --git a/lib_dasp/lib_dasp_density/density/Smooth.hpp b/lib_dasp/lib_dasp_density/density/Smooth.hpp
+index 1f232f4..3f26650 100644
+--- a/lib_dasp/lib_dasp_density/density/Smooth.hpp
++++ b/lib_dasp/lib_dasp_density/density/Smooth.hpp
+@@ -1,7 +1,7 @@
+ #ifndef INCLUDED_DENSITY_SMOOTH_HPP
+ #define INCLUDED_DENSITY_SMOOTH_HPP
+ 
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ 
+ namespace density
+ {
+diff --git a/lib_dasp/lib_dasp_density/density/Visualization.hpp b/lib_dasp/lib_dasp_density/density/Visualization.hpp
+index 789f4e5..083255d 100644
+--- a/lib_dasp/lib_dasp_density/density/Visualization.hpp
++++ b/lib_dasp/lib_dasp_density/density/Visualization.hpp
+@@ -3,7 +3,7 @@
+ 
+ #include <Danvil/Color.h>
+ #include <Slimage/Slimage.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace density
+diff --git a/lib_dasp/lib_dasp_graphseg/Common.hpp b/lib_dasp/lib_dasp_graphseg/Common.hpp
+index 4b2fb40..23a6796 100644
+--- a/lib_dasp/lib_dasp_graphseg/Common.hpp
++++ b/lib_dasp/lib_dasp_graphseg/Common.hpp
+@@ -9,7 +9,7 @@
+ #define DASP_SPECTRAL_COMMON_HPP
+ 
+ #include <boost/graph/adjacency_list.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace graphseg
+diff --git a/lib_dasp/lib_dasp_graphseg/Rendering.hpp b/lib_dasp/lib_dasp_graphseg/Rendering.hpp
+index 5d2fb92..8c12b79 100644
+--- a/lib_dasp/lib_dasp_graphseg/Rendering.hpp
++++ b/lib_dasp/lib_dasp_graphseg/Rendering.hpp
+@@ -7,7 +7,7 @@
+ #include <GL/glew.h>
+ #include <graphseg/as_range.hpp>
+ #include <boost/graph/adjacency_list.hpp>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ 
+ namespace graphseg
+ {
+diff --git a/lib_dasp/lib_dasp_graphseg/spectral/eigen.cpp b/lib_dasp/lib_dasp_graphseg/spectral/eigen.cpp
+index 717da4a..efda39e 100644
+--- a/lib_dasp/lib_dasp_graphseg/spectral/eigen.cpp
++++ b/lib_dasp/lib_dasp_graphseg/spectral/eigen.cpp
+@@ -1,5 +1,5 @@
+ #include "solver.hpp"
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #ifdef SPECTRAL_VERBOSE
+ #	include <iostream>
+ #endif
+diff --git a/lib_dasp/lib_dasp_pds/pds/Fattal.hpp b/lib_dasp/lib_dasp_pds/pds/Fattal.hpp
+index 2fce379..9edaac0 100644
+--- a/lib_dasp/lib_dasp_pds/pds/Fattal.hpp
++++ b/lib_dasp/lib_dasp_pds/pds/Fattal.hpp
+@@ -10,7 +10,7 @@
+ //----------------------------------------------------------------------------//
+ #include <Slimage/Slimage.hpp>
+ #include <Danvil/Tools/FunctionCache.h>
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ #include <algorithm>
+ #include <cmath>
+diff --git a/lib_dasp/lib_dasp_pds/pds/PDS.hpp b/lib_dasp/lib_dasp_pds/pds/PDS.hpp
+index 91185d3..8be9ba1 100644
+--- a/lib_dasp/lib_dasp_pds/pds/PDS.hpp
++++ b/lib_dasp/lib_dasp_pds/pds/PDS.hpp
+@@ -1,7 +1,7 @@
+ #ifndef INCLUDED_PDS_PDS_HPP
+ #define INCLUDED_PDS_PDS_HPP
+ 
+-#include <Eigen/Dense>
++#include <eigen3/Eigen/Dense>
+ #include <vector>
+ 
+ namespace pds
+

--- a/docker/makefile
+++ b/docker/makefile
@@ -1,0 +1,55 @@
+# Persistence of storage with in/ and out/ local subdirs.
+# Presumes .bmp images are ready in `in/`. See `convert` if needed.
+run: build
+	mkdir -p in/ raw/ out/
+	docker run --rm -ti \
+		-v `pwd`/in:/app/in \
+		-v `pwd`/out:/app/out \
+		-v `pwd`/raw:/app/raw:ro \
+		superpixels bash
+
+build:
+	docker build -t superpixels .
+
+# Images need to be in .bmp format, so `imagemagick` is bundled in the container for convenience
+# Put images in ./raw/
+convert:
+	mkdir -p in/
+	rm -f in/* || true
+	docker run --rm -ti -v `pwd`/in:/app/in -v `pwd`/raw:/app/raw:ro superpixels convert raw/*.png in/*.bmp
+
+# Example of animating frames within the container - helpful for batch processing.
+extract:
+	mkdir -p in/
+	rm -f in/* || true
+	docker run --rm -ti \
+		-v `pwd`/in:/app/in \
+		-v `pwd`/raw:/app/raw:ro \
+		ffmpeg -i /raw/video.mp4 \
+		-vf fps=24 \
+		in/frame%04d.bmp
+
+animate:
+	docker run --rm -ti \
+		-v `pwd`/out:/app/out \
+		ffmpeg -i out/frame%04d.png \
+		-c:v libx264 \
+		-vf "fps=24,format=yuv420p,pad=ceil(iw/2)*2:ceil(ih/2)*2" \
+		out/out.mp4
+
+clean_out:
+	mkdir -p out/
+	rm -f out/* || true
+
+## Example algorithms section
+ifndef s
+override s = 100
+endif
+
+# Example of help commands to inspect arguments.
+help_mss:
+	docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out superpixels bash -c "/app/super/bin/mss_cli --help"
+
+mss: clean_out
+	docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out superpixels bash -c "/app/super/bin/mss_cli -w -i /in --vis /out -s $(s) --csv /out"
+

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -2,7 +2,8 @@
 
 For getting started quickly:
 
-* [#Quick Start](quick-start)
+* [Getting Started](#getting-started)
+* [Docker](../docker/README.md)
 
 For details, there are three main components that need to be built:
 


### PR DESCRIPTION
Only thing I think needs verification is `glog`... how can I test that it's linked correctly? I left that line commented out and didn't edit the cmake file to find it, perhaps because `libgoogle-glog-dev` was already found? Not sure.

- built on something recent-ish as a base image. should be a good starting point and slightly more secure than what I built originally (see #15)
- `eigen` imports needed to be added once I was building on a newer OS (past 14.04)
- adds some image-related utilities
- fixes typo in BUILDING.md
- adds some usage examples via `makefile` in `docker/` directory
- I have tested about 10 algorithms, but included syntax for just one so as not to bloat the `makefile`.
- I refrained from linking a docker-hub image. But if you'd like, I can publish one so that people can skip the build step. Should help with reproducibility just a bit more. Ideally though that would be built / published from the repo as an action.

Any and all feedback welcome.