### PR TITLE
patch for CW + updated README

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build-time dependencies (caches apt lists between builds)
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get update && \
     apt-get install -yqq --no-install-recommends \
       autotools-dev automake build-essential \
@@ -70,10 +71,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Minimal runtime tools & libs
 RUN apt-get update && \
     apt-get install -yqq --no-install-recommends \
-      ca-certificates \
-      ffmpeg \
-      potrace \
-      graphicsmagick-imagemagick-compat \
+    #   ca-certificates \
+    #   ffmpeg \
+    #   potrace \
+    #   graphicsmagick-imagemagick-compat \
       dumb-init \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,48 +1,81 @@
-# Docker image
-As years pass by and operating systems get upgraded, it's important to have at least a working snapshot of a computational environment.
+# Docker Image
+As years pass by and operating systems get upgraded, it's important to have a working snapshot of a computational environment that demonstrates successful compilation of the code in this repository.
+This directory aims to provide such a reference implementation.
 
-A docker image has been contributed to help facilitate the use of many of the algorithms. It is not complete in scope, but should act as a starting place for compiling and using the code in this repository.
+Here you will find a `Dockerfile` which makes use of `--build-arg BASE_IMAGE=...` to modify the base operating system used in the image.
+
+The `Dockerfile` relies on `docker.patch` and `timer-patch.sh` to patch the code in a manner which is compatible (as of 2025-06-15) with the following base images:
+
+- `debian:buster:20240612-slim`
+- `debian:bullseye:20250520-slim`
+- `debian:bookworm:20250520-slim`
+- `debian:trixie:20250520-slim`
+
+The patch file applies a number of changes to keep the code backwards-compatible but make use of the latest syntax, libraries, and features of the C++ standard.
+- Most of the changes involve detecting the `OpenCV` version and using the appropriate API.
+- Several patches involve updating the `eigen3` syntax.
+- `PCL` imports are slimmed down for a headless environment, and some methods are patched based on version.
+- `boost::timer` patches are performed with `timer-patch.sh`, which became enforced in `debian:trixie` but were warnings prior to that release.
+- In `Dockerfile`, there is an inline `sed` to `CImg` to make it compatible with `debian:trixie`.
+- In `Dockerfile`, there is an inline `sed` to `CMakeLists.txt` to scope the use of `cmake` from `2.8.12` up to version `3.25`.
+- ARM64 compatibility is achieved by patching `ETPS` to use NEON instructions in place of SSE instructions.
+
+The `Dockerfile` uses multi-stage builds to reduce the size of the final image by using the first stage to build the code and the second stage to copy the binaries into the final image and configure the `PATH`.
+
+If you are looking to compile this project on your own operating system, the `Dockerfile` and `docker.patch` + `timer-patch.sh` files can serve as a guide.
+
+If you are looking to run the binaries, they have been pre-built and published to [Docker Hub](https://hub.docker.com/r/mathematicalmichael/superpixels/tags).
+
 
 A `makefile` is supplied with example usage of the container, including an example of how to prepare images for the algorithms.
 
-`ffmpeg`, `graphicsmagick`, and `potrace` are installed in the container as utilities related to image processing. `git` and `python 3.11.4` are also bundled.
+Usage relies on the user to create `in/` and `out/` sub-directories, and to place sample images in the `in/` directory (in `.bmp`, `.png`, or `.jpeg`/`.jpg` format).
 
+```bash
+mkdir -p in
+mkdir -p out
+```
 
 ## Changes
 In addition to the algorithms enabled by default, the following have been changed to `ON`:
 
-- BUILD_VC
+- BUILD_VC (non-commercial use only)
 - BUILD_FH
 - BUILD_MSS
-- BUILD_PB
+- BUILD_PB (non-commercial use only)
 - BUILD_PRESLIC
 - BUILD_W
 - BUILD_LSC
 - BUILD_CCS
+- BUILD_CW
 - BUILD_DASP
 - BUILD_VCCS
 - BUILD_REFH
 - BUILD_VLSLIC
 
 BUILD_CIS is `OFF` due to licensing
-BUILD_CW is `OFF` due to cvGetMatSize declaration error
+NOTE: BUILD_ETPS (non-commercial use only) is `ON` and has been patched to use NEON instructions on ARM64 in place of the SSE instructions on x86_64.
+
 
 The Matlab algorithms have been left disabled due to licensing concerns with the language.
 If you know how to safely ship matlab in a container (or want to attempt a migration to Octave), contributions are welcome.
 
 
 # Quick Start
-Reference the `makefile` (which acts like a collection of shell-scripts), for docker usage syntax. Adapt it to your needs, as it is meant to provide a reference implementation which may or may not align with your expectations (e.g., folder names, locations, etc).
+
+Reference the `makefile` (which here acts like a collection of shell-scripts), for docker build and run syntax. 
+Adapt it to your needs, as it is meant to provide a reference implementation which may or may not align with your expectations (e.g., folder names, locations, etc).
+
+For example, to run the `MSS` algorithm, you can use the following command:
 
 ```bash
-make run
+make mss
 ```
 
-Will start `bash` in an interactive emphemeral container, with `raw` being a read-only bind-mounted directory, and `in` being where you put `.bmp` images. See `make convert` for an example of how to prepare your images using the docker container.
+Which will ensure an image is built/tagged, and then runs `mss_cli` to process your `in/` directory and save the results in `out/`.
 
 There is an example of one algorithm's syntax in the [`makefile`][./makefile]:
 
 ```bash
 make help_mss
 ```
-

--- a/docker/docker.patch
+++ b/docker/docker.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 104fd9d..c6b3c24 100644
+index 104fd9d..f1f86f1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -31,6 +31,10 @@
+@@ -31,39 +31,43 @@
  cmake_minimum_required(VERSION 2.8)
  project(superpixel_benchmark)
  
@@ -13,42 +13,51 @@ index 104fd9d..c6b3c24 100644
  set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
  set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
  set(CMAKE_CXX_FLAGS  "-Wall -Wno-sign-compare -g -std=c++0x -O4 -fpermissive")
-@@ -45,22 +49,22 @@ option(BUILD_CRS "Build CRS" ON)
- option(BUILD_ERGC "Build ERGC" ON)
+ 
+ # "Core algorithms" as recommended:
+-option(BUILD_ETPS "Build ETPS" ON)
+-option(BUILD_SLIC "Build SLIC" ON)
+-option(BUILD_SEEDS "Build SEEDS" ON)
+-option(BUILD_RESEEDS "Build reSEEDS" ON)
+-option(BUILD_ERS "Build ERS" ON)
+-option(BUILD_CRS "Build CRS" ON)
+-option(BUILD_ERGC "Build ERGC" ON)
++option(BUILD_ETPS "Build ETPS" OFF)
++option(BUILD_SLIC "Build SLIC" OFF)
++option(BUILD_SEEDS "Build SEEDS" OFF)
++option(BUILD_RESEEDS "Build reSEEDS" OFF)
++option(BUILD_ERS "Build ERS" OFF)
++option(BUILD_CRS "Build CRS" OFF)
++option(BUILD_ERGC "Build ERGC" OFF)
  
  # Remaining algorithms:
--option(BUILD_FH "Build FH" OFF)
--option(BUILD_MSS "Build MSS" OFF)
--option(BUILD_PB "Build PB" OFF)
--option(BUILD_PRESLIC "Build preSLIC" OFF)
-+# CW is OFF b/c cvGetMatSize declaration error
-+# CIS is OFF bc of licensing
-+option(BUILD_FH "Build FH" ON)
-+option(BUILD_MSS "Build MSS" ON)
-+option(BUILD_PB "Build PB" ON)
-+option(BUILD_PRESLIC "Build preSLIC" ON)
- option(BUILD_CW "Build CW" OFF)
++# CIS is OFF due to restrictive licensing
++
+ option(BUILD_FH "Build FH" OFF)
+ option(BUILD_MSS "Build MSS" OFF)
+ option(BUILD_PB "Build PB" OFF)
+ option(BUILD_PRESLIC "Build preSLIC" OFF)
+-option(BUILD_CW "Build CW" OFF)
++option(BUILD_CW "Build CW" ON)
  option(BUILD_CIS "Build CIS" OFF)
--option(BUILD_W "Build W" OFF)
--option(BUILD_LSC "Build LSC" OFF)
+ option(BUILD_W "Build W" OFF)
+ option(BUILD_LSC "Build LSC" OFF)
+ option(BUILD_VC "Build VC" OFF)
+ option(BUILD_CCS "Build CCS" OFF)
 -option(BUILD_VC "Build VC" OFF)
 -option(BUILD_CCS "Build CCS" OFF)
--option(BUILD_VC "Build VC" OFF)
--option(BUILD_CCS "Build CCS" OFF)
--option(BUILD_DASP "Build DASP" OFF)
--option(BUILD_VCCS "Build VCCS" OFF)
-+option(BUILD_W "Build W" ON)
-+option(BUILD_LSC "Build LSC" ON)
-+option(BUILD_VC "Build VC" ON)
-+option(BUILD_CCS "Build CCS" ON)
-+option(BUILD_DASP "Build DASP" ON)
-+option(BUILD_VCCS "Build VCCS" ON)
- option(BUILD_REFH "Build reFH" ON)
--option(BUILD_VLSLIC "Build vlSLIC" OFF)
-+option(BUILD_VLSLIC "Build vlSLIC" ON)
+ option(BUILD_DASP "Build DASP" OFF)
+ option(BUILD_VCCS "Build VCCS" OFF)
+-option(BUILD_REFH "Build reFH" ON)
++option(BUILD_REFH "Build reFH" OFF)
+ option(BUILD_VLSLIC "Build vlSLIC" OFF)
  
  # Examples:
- option(BUILD_EXAMPLES "Build examples" ON)
+-option(BUILD_EXAMPLES "Build examples" ON)
++option(BUILD_EXAMPLES "Build examples" OFF)
+ 
+ # Toolbox
+ add_subdirectory(lib_eval)
 diff --git a/cmake/FindGlog.cmake b/cmake/FindGlog.cmake
 index a529148..944b52d 100644
 --- a/cmake/FindGlog.cmake
@@ -234,6 +243,57 @@ index 01992f1..19018e0 100644
  /** \brief Wrapper for running CRS on OpenCV images.
   * \author David Stutz
   */
+diff --git a/lib_cw/compact_watershed.cpp b/lib_cw/compact_watershed.cpp
+index d85c8d7..dee990f 100644
+--- a/lib_cw/compact_watershed.cpp
++++ b/lib_cw/compact_watershed.cpp
+@@ -67,7 +67,9 @@
+  */
+ 
+ #include "compact_watershed.h"
+-#include <cxmisc.h>
++#include <opencv2/core/version.hpp>
++#include <opencv2/core/core_c.h>
++#include <opencv2/core/types_c.h>
+ 
+ /****************************************************************************************\
+ *                                Compact Watershed                                      *
+@@ -192,7 +194,7 @@ namespace cws
+       if( !CV_ARE_SIZES_EQ( src, dst ))
+           CV_Error( CV_StsUnmatchedSizes, "The input and output images must have the same size" );
+ 
+-      size = cvGetMatSize(src);
++      size = cvSize(src->cols, src->rows);
+       storage = cvCreateMemStorage();
+ 
+       istep = src->step;
+@@ -353,11 +355,22 @@ namespace cws
+   }
+ 
+ 
+-  void compact_watershed( InputArray _src, InputOutputArray markers , float compValStep)
++  void compact_watershed(InputArray _src, InputOutputArray markers, float compValStep)
+   {
+-      Mat src = _src.getMat();
+-      CvMat c_src = _src.getMat(), c_markers = markers.getMat();
+-      cws::cvWatershed( &c_src, &c_markers,compValStep );
++    cv::Mat src = _src.getMat();
++    cv::Mat markerMat = markers.getMat();
++
++  #if CV_VERSION_MAJOR < 4
++    // OpenCV 2.x/3.x: Use the old C API conversion
++    CvMat c_src = src;
++    CvMat c_markers = markerMat;
++    cws::cvWatershed(&c_src, &c_markers, compValStep);
++  #else
++    // OpenCV 4.x: C API is deprecated; use the data pointer to create a CvMat header
++    CvMat c_src = cvMat(src.rows, src.cols, src.type(), src.data);
++    CvMat c_markers = cvMat(markerMat.rows, markerMat.cols, markerMat.type(), markerMat.data);
++    cws::cvWatershed(&c_src, &c_markers, compValStep);
++  #endif
+   }
+ } // namespace cws
+ 
 diff --git a/lib_dasp/lib_dasp/Graph.hpp b/lib_dasp/lib_dasp/Graph.hpp
 index f095835..75d3f85 100755
 --- a/lib_dasp/lib_dasp/Graph.hpp

--- a/docker/docker.patch
+++ b/docker/docker.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 104fd9d..f1f86f1 100644
+index 104fd9d..1d158cc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -31,39 +31,43 @@
+@@ -31,6 +31,10 @@
  cmake_minimum_required(VERSION 2.8)
  project(superpixel_benchmark)
  
@@ -13,51 +13,43 @@ index 104fd9d..f1f86f1 100644
  set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
  set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
  set(CMAKE_CXX_FLAGS  "-Wall -Wno-sign-compare -g -std=c++0x -O4 -fpermissive")
- 
- # "Core algorithms" as recommended:
--option(BUILD_ETPS "Build ETPS" ON)
--option(BUILD_SLIC "Build SLIC" ON)
--option(BUILD_SEEDS "Build SEEDS" ON)
--option(BUILD_RESEEDS "Build reSEEDS" ON)
--option(BUILD_ERS "Build ERS" ON)
--option(BUILD_CRS "Build CRS" ON)
--option(BUILD_ERGC "Build ERGC" ON)
-+option(BUILD_ETPS "Build ETPS" OFF)
-+option(BUILD_SLIC "Build SLIC" OFF)
-+option(BUILD_SEEDS "Build SEEDS" OFF)
-+option(BUILD_RESEEDS "Build reSEEDS" OFF)
-+option(BUILD_ERS "Build ERS" OFF)
-+option(BUILD_CRS "Build CRS" OFF)
-+option(BUILD_ERGC "Build ERGC" OFF)
+@@ -45,22 +49,22 @@ option(BUILD_CRS "Build CRS" ON)
+ option(BUILD_ERGC "Build ERGC" ON)
  
  # Remaining algorithms:
+-option(BUILD_FH "Build FH" OFF)
+-option(BUILD_MSS "Build MSS" OFF)
+-option(BUILD_PB "Build PB" OFF)
+-option(BUILD_PRESLIC "Build preSLIC" OFF)
+-option(BUILD_CW "Build CW" OFF)
 +# CIS is OFF due to restrictive licensing
 +
- option(BUILD_FH "Build FH" OFF)
- option(BUILD_MSS "Build MSS" OFF)
- option(BUILD_PB "Build PB" OFF)
- option(BUILD_PRESLIC "Build preSLIC" OFF)
--option(BUILD_CW "Build CW" OFF)
++option(BUILD_FH "Build FH" ON)
++option(BUILD_MSS "Build MSS" ON)
++option(BUILD_PB "Build PB" ON)
++option(BUILD_PRESLIC "Build preSLIC" ON)
 +option(BUILD_CW "Build CW" ON)
  option(BUILD_CIS "Build CIS" OFF)
- option(BUILD_W "Build W" OFF)
- option(BUILD_LSC "Build LSC" OFF)
- option(BUILD_VC "Build VC" OFF)
- option(BUILD_CCS "Build CCS" OFF)
+-option(BUILD_W "Build W" OFF)
+-option(BUILD_LSC "Build LSC" OFF)
 -option(BUILD_VC "Build VC" OFF)
 -option(BUILD_CCS "Build CCS" OFF)
- option(BUILD_DASP "Build DASP" OFF)
- option(BUILD_VCCS "Build VCCS" OFF)
--option(BUILD_REFH "Build reFH" ON)
-+option(BUILD_REFH "Build reFH" OFF)
- option(BUILD_VLSLIC "Build vlSLIC" OFF)
+-option(BUILD_VC "Build VC" OFF)
+-option(BUILD_CCS "Build CCS" OFF)
+-option(BUILD_DASP "Build DASP" OFF)
+-option(BUILD_VCCS "Build VCCS" OFF)
++option(BUILD_W "Build W" ON)
++option(BUILD_LSC "Build LSC" ON)
++option(BUILD_VC "Build VC" ON)
++option(BUILD_CCS "Build CCS" ON)
++option(BUILD_DASP "Build DASP" ON)
++option(BUILD_VCCS "Build VCCS" ON)
+ option(BUILD_REFH "Build reFH" ON)
+-option(BUILD_VLSLIC "Build vlSLIC" OFF)
++option(BUILD_VLSLIC "Build vlSLIC" ON)
  
  # Examples:
--option(BUILD_EXAMPLES "Build examples" ON)
-+option(BUILD_EXAMPLES "Build examples" OFF)
- 
- # Toolbox
- add_subdirectory(lib_eval)
+ option(BUILD_EXAMPLES "Build examples" ON)
 diff --git a/cmake/FindGlog.cmake b/cmake/FindGlog.cmake
 index a529148..944b52d 100644
 --- a/cmake/FindGlog.cmake
@@ -244,7 +236,7 @@ index 01992f1..19018e0 100644
   * \author David Stutz
   */
 diff --git a/lib_cw/compact_watershed.cpp b/lib_cw/compact_watershed.cpp
-index d85c8d7..dee990f 100644
+index d85c8d7..ab87c39 100644
 --- a/lib_cw/compact_watershed.cpp
 +++ b/lib_cw/compact_watershed.cpp
 @@ -67,7 +67,9 @@
@@ -280,17 +272,17 @@ index d85c8d7..dee990f 100644
 +    cv::Mat src = _src.getMat();
 +    cv::Mat markerMat = markers.getMat();
 +
-+  #if CV_VERSION_MAJOR < 4
-+    // OpenCV 2.x/3.x: Use the old C API conversion
-+    CvMat c_src = src;
-+    CvMat c_markers = markerMat;
-+    cws::cvWatershed(&c_src, &c_markers, compValStep);
-+  #else
-+    // OpenCV 4.x: C API is deprecated; use the data pointer to create a CvMat header
-+    CvMat c_src = cvMat(src.rows, src.cols, src.type(), src.data);
-+    CvMat c_markers = cvMat(markerMat.rows, markerMat.cols, markerMat.type(), markerMat.data);
-+    cws::cvWatershed(&c_src, &c_markers, compValStep);
-+  #endif
++    #if CV_VERSION_MAJOR < 4
++      // OpenCV 2.x/3.x: Use the old C API conversion
++      CvMat c_src = src;
++      CvMat c_markers = markerMat;
++      cws::cvWatershed(&c_src, &c_markers, compValStep);
++    #else
++      // OpenCV 4.x: C API is deprecated; use the data pointer to create a CvMat header
++      CvMat c_src = cvMat(src.rows, src.cols, src.type(), src.data);
++      CvMat c_markers = cvMat(markerMat.rows, markerMat.cols, markerMat.type(), markerMat.data);
++      cws::cvWatershed(&c_src, &c_markers, compValStep);
++    #endif
    }
  } // namespace cws
  

--- a/docker/makefile
+++ b/docker/makefile
@@ -1,16 +1,16 @@
 # Persistence of storage with in/ and out/ local subdirs.
 
 build-buster:
-	docker build --build-arg BASE_IMAGE=debian:buster-20240612-slim   -t superpixels:buster-20240612-slim .
+	docker build --progress plain --build-arg BASE_IMAGE=debian:buster-20240612-slim   -t superpixels:buster-20240612-slim .
 
 build-bullseye:
-	docker build --build-arg BASE_IMAGE=debian:bullseye-20250520-slim -t superpixels:bullseye-20250520-slim .
+	docker build --progress plain --build-arg BASE_IMAGE=debian:bullseye-20250520-slim -t superpixels:bullseye-20250520-slim .
 
 build-bookworm:
-	docker build --build-arg BASE_IMAGE=debian:bookworm-20250520-slim -t superpixels:bookworm-20250520-slim .
+	docker build --progress plain --build-arg BASE_IMAGE=debian:bookworm-20250520-slim -t superpixels:bookworm-20250520-slim .
 
 build-trixie:
-	docker build --build-arg BASE_IMAGE=debian:trixie-20250520-slim   -t superpixels:trixie-20250520-slim .
+	docker build --progress plain --build-arg BASE_IMAGE=debian:trixie-20250520-slim   -t superpixels:trixie-20250520-slim .
 
 build: build-buster
 	docker tag superpixels:buster-20240612-slim superpixels:latest
@@ -25,5 +25,5 @@ help_mss:
 	docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out superpixels mss_cli --help
 
 # Example of running the MSS algorithm with a specified scale.
-mss: clean_out
+mss: build
 	docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out superpixels mss_cli -w -i /in --vis /out -s $(s) --csv /out


### PR DESCRIPTION
should be much easier to review a small patch now. good test of future maintenance PRs.

this change adds support to final C++ algorithm (CW) that could be built without fetching external code (i.e., CIS).

![image](https://github.com/user-attachments/assets/22f38677-b2ac-456c-a2c5-9e56cd8ca4c8)

after a bit of testing, `lib_dasp` and `lib_vccs` do work after all ... my testing script just didn't handle the `--depth` argument (missing), so no changes were necessary. the boost:any_cast error I was encountering was hiding the underlying "missing parameter" issue.

validated that CW runs on all four operating systems.
```bash
docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out mathematicalmichael/superpixels:buster-20240612-slim cw_cli -w -i /in --vis /out -s 500 --csv /out
docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out mathematicalmichael/superpixels:bullseye-20250520-slim cw_cli -w -i /in --vis /out -s 500 --csv /out
docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out mathematicalmichael/superpixels:bookworm-20250520-slim cw_cli -w -i /in --vis /out -s 500 --csv /out
docker run --rm -ti -v `pwd`/in:/in -v `pwd`/out:/out mathematicalmichael/superpixels:trixie-20250520-slim cw_cli -w -i /in --vis /out -s 500 --csv /out
```

also commented out the "tools" for an even slimmer image by default.